### PR TITLE
Fix Cast System crashes on caster/viewer logout

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -226,13 +226,14 @@ class Player : public Creature, public Cylinder
 
 		void kickCastViewers()
 		{
-			for(AutoList<ProtocolGame>::iterator it = cSpectators.begin(); it != cSpectators.end(); ++it)
-			{
-				if(it->second->getPlayer() == this)
-				{
+			AutoList<ProtocolGame>::iterator it = cSpectators.begin();
+			while (it != cSpectators.end()) {
+				if (it->second->getPlayer() == this) {
 					it->second->disconnect();
 					it->second->unRef();
-					removeCastViewer(it->first);
+					it = cSpectators.erase(it);
+				} else {
+					++it;
 				}
 			}
 			cast = PlayerCast();
@@ -246,6 +247,7 @@ class Player : public Creature, public Cylinder
 					it->second->disconnect();
 					it->second->unRef();
 					removeCastViewer(it->first);
+					return;
 				}
 		}
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -305,6 +305,7 @@ bool ProtocolGame::logout(bool displayEffect, bool forceLogout)
 
 					connection->close();
 					player->removeCastViewer(it->first);
+					return false;
 				}
 		return false;
 	}


### PR DESCRIPTION
As described here:
https://otland.net/threads/crash-with-fir3elements-3777-log-provided.281821/

Cast System sometimes - not always - crashes server, when caster/viewer logouts.