### PR TITLE
Update spawn.cpp, fix the bug!

### DIFF
--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -156,7 +156,7 @@ bool Spawns::parseSpawnNode(xmlNodePtr p, bool checkDuplicate)
 				placePos.z /*+*/= intValue;
 
 			Direction direction = NORTH;
-			if(readXMLInteger(tmpNode, "direction", intValue) && direction >= EAST && direction <= WEST)
+			if(readXMLInteger(tmpNode, "direction", intValue) && direction >= NORTH && direction <= WEST)
 				direction = (Direction)intValue;
 
 			spawn->addMonster(name, placePos, direction, interval);
@@ -178,7 +178,7 @@ bool Spawns::parseSpawnNode(xmlNodePtr p, bool checkDuplicate)
 				placePos.z /*+*/= intValue;
 
 			Direction direction = NORTH;
-			if(readXMLInteger(tmpNode, "direction", intValue) && direction >= EAST && direction <= WEST)
+			if(readXMLInteger(tmpNode, "direction", intValue) && direction >= NORTH && direction <= WEST)
 				direction = (Direction)intValue;
 
 			Npc* npc = Npc::createNpc(name);


### PR DESCRIPTION
enum Direction
{
	NORTH = 0,
	EAST = 1,
	SOUTH = 2,
	WEST = 3,
	SOUTHWEST = 4,
	SOUTHEAST = 5,
	NORTHWEST = 6,
	NORTHEAST = 7
};

it was direction >= EAST, but when default direction is NORTH, it was actually skipping this and making the directions not work with monsters and npc (Im talking about setting them in map editor)